### PR TITLE
chore: add typecheck npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "postinstall": "npm run rmrf && tsc -p tsconfig.prod.json && npm run build:front",
     "ts-start": "cross-env DEBUG=WebJamSocketServer:* node --watch --trace-warnings build/src/index.js",
     "ts-watch": "tsc -w",
+    "typecheck": "tsc --noEmit",
     "test:lint": "eslint . --fix",
     "test:local": "eslint . --fix && npm run test:unit && npm run cc",
     "test:unit": "vitest run",


### PR DESCRIPTION
## Summary

Adds `npm run typecheck` (\`tsc --noEmit\`) so CI and local devs can verify TypeScript without a full build. Mirrors the script already present in JaMmusic and web-jam-back.

## Test plan

- [x] \`npm run typecheck\` exits 0 against the current \`dev\` snapshot.
- [x] \`npm test\` still passes (66/66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)