### PR TITLE
feat(eslint): integrate eslint-plugin-sonarjs (closes #207)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import nodePlugin from 'eslint-plugin-n';
 import securityPlugin from 'eslint-plugin-security';
+import sonarjs from 'eslint-plugin-sonarjs';
 import globals from 'globals';
 
 export default tseslint.config(
@@ -22,6 +23,7 @@ export default tseslint.config(
   js.configs.recommended,
   nodePlugin.configs['flat/recommended-module'],
   securityPlugin.configs.recommended,
+  sonarjs.configs.recommended,
   {
     files: ['**/*.ts'],
     extends: [...tseslint.configs.recommendedTypeChecked],
@@ -61,6 +63,16 @@ export default tseslint.config(
       'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],
       'one-var': ['error', { var: 'never', let: 'always', const: 'never' }],
       'max-len': ['error', { code: 150 }],
+    },
+  },
+  {
+    // Test-only override: deeply-nested arrow chains are the clearest way to
+    // build mock factories (e.g. socketcluster's receiver/consumer/next chain),
+    // and refactoring them into named helpers reduces readability rather than
+    // improving it. Keep the rule active for src/.
+    files: ['test/**/*.ts'],
+    rules: {
+      'sonarjs/no-nested-functions': 'off',
     },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint": "^10.2.1",
         "eslint-plugin-n": "^17.24.0",
         "eslint-plugin-security": "^4.0.0",
+        "eslint-plugin-sonarjs": "^4.0.3",
         "globals": "^17.5.0",
         "supertest": "^7.2.2",
         "typescript-eslint": "^8.59.1",
@@ -1902,6 +1903,19 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2699,6 +2713,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
+      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.4.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.7.4",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -3137,6 +3175,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -3647,6 +3692,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -4057,6 +4112,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -4726,6 +4788,33 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -4909,6 +4998,21 @@
         "async-stream-emitter": "^7.0.1",
         "skeleton-rendezvous": "^1.1.2",
         "socketcluster-client": "^20.0.0"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint": "^10.2.1",
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-security": "^4.0.0",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "globals": "^17.5.0",
     "supertest": "^7.2.2",
     "typescript-eslint": "^8.59.1",

--- a/src/AgController/index.ts
+++ b/src/AgController/index.ts
@@ -40,8 +40,8 @@ class AgController {
     (async () => {
       let disconnect: { value: undefined; done: any; };
       const dConsumer = client.listener('disconnect').createConsumer();
-      while (true) { // eslint-disable-line no-constant-condition
-        disconnect = await dConsumer.next();// eslint-disable-line no-await-in-loop
+      while (true) {  
+        disconnect = await dConsumer.next(); 
         clearInterval(interval);
         if (disconnect.value !== undefined) {
           const index = this.clients.indexOf(client.id);
@@ -55,6 +55,9 @@ class AgController {
 
   sendPulse(client:IClient):void {
     const interval = setInterval(() => {
+      // sonarjs/pseudo-random: this is a non-security pulse heartbeat for clients
+      // (an arbitrary 0-4 number transmitted every second). Math.random is fine here.
+      // eslint-disable-next-line sonarjs/pseudo-random
       client.socket.transmit('pulse', { number: Math.floor(Math.random() * 5) });
     }, 1000);
     debug(`num clients: ${this.clients.length}`);
@@ -89,14 +92,17 @@ class AgController {
     (async () => {
       let receiver: { value: number; done: any; };
       const rConsumer = client.socket.receiver('initial message').createConsumer();
-      while (true) { // eslint-disable-line no-constant-condition
-        receiver = await rConsumer.next();// eslint-disable-line no-await-in-loop
+      while (true) {  
+        receiver = await rConsumer.next(); 
         debug(`received initial message: ${receiver.value}`);
         if (receiver.value === 123) {
-          await this.sendTours(client);// eslint-disable-line no-await-in-loop
-          await this.sendBooks(client);// eslint-disable-line no-await-in-loop
-        } else break;
-        /* istanbul ignore else */if (receiver.done) break;
+          await this.sendTours(client);
+          await this.sendBooks(client);
+        } else {
+          break;
+        }
+        /* istanbul ignore else */
+        if (receiver.done) break;
       }
     })();
   }
@@ -117,14 +123,14 @@ class AgController {
     (async () => {
       let receiver: { value: { token: string; image: any }, done: any; };
       const rConsumer = client.socket.receiver('newImage').createConsumer();
-      while (true) { // eslint-disable-line no-constant-condition
-        receiver = await rConsumer.next();// eslint-disable-line no-await-in-loop
+      while (true) {  
+        receiver = await rConsumer.next(); 
         debug(`received newImage message: ${JSON.stringify(receiver.value)}`);
         if (!receiver.value) break;
         if (typeof receiver.value.token === 'string'
             && typeof receiver.value.image.title === 'string' && typeof receiver.value.image.url === 'string'
         ) {
-          await this.handleImage('createDocs', receiver.value.image, 'imageCreated');// eslint-disable-line no-await-in-loop
+          await this.handleImage('createDocs', receiver.value.image, 'imageCreated'); 
         }
         /* istanbul ignore else */if (receiver.done) break;
       }
@@ -138,10 +144,10 @@ class AgController {
   ):Promise<string> {
     const { editPic, token } = data;
     const {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
+       
       _id, title, url, comments, 
     } = editPic;
-    let r: any;// eslint-disable-next-line security/detect-object-injection
+    let r: any; 
     if (typeof token !== 'string') throw new Error('invalid token');
     try { r = await this.bookController.findByIdAndUpdate(_id, { title, url, comments }); } catch (e) {
       const eMessage = (e as Error).message;
@@ -157,12 +163,12 @@ class AgController {
     (async () => {
       let receiver: { value: { data: string; token: string; }; done: any; };
       const rConsumer = client.socket.receiver('deleteImage').createConsumer();
-      while (true) { // eslint-disable-line no-constant-condition
-        receiver = await rConsumer.next();// eslint-disable-line no-await-in-loop
+      while (true) {  
+        receiver = await rConsumer.next(); 
         debug(`received deleteImage message: ${JSON.stringify(receiver.value)}`);
         if (!receiver.value) break;
         if (typeof receiver.value.token === 'string' && typeof receiver.value.data === 'string') {
-          await this.handleImage('deleteById', receiver.value.data, 'imageDeleted');// eslint-disable-line no-await-in-loop
+          await this.handleImage('deleteById', receiver.value.data, 'imageDeleted'); 
         }
         /* istanbul ignore else */if (receiver.done) break;
       }
@@ -174,8 +180,8 @@ class AgController {
       let receiver: { value: { token: string; 
         tour: { datetime: Date; venue: string; city:string, usState: string }; }; done: any; };
       const rConsumer = client.socket.receiver('newTour').createConsumer();
-      while (true) { // eslint-disable-line no-constant-condition
-        receiver = await rConsumer.next();// eslint-disable-line no-await-in-loop
+      while (true) {  
+        receiver = await rConsumer.next(); 
         let decoded, user, goodRoles;
         if (!receiver.value) break;
         try {
@@ -191,7 +197,7 @@ class AgController {
           }
           if (receiver.value.tour.datetime && receiver.value.tour.city 
             && receiver.value.tour.usState && receiver.value.tour.venue) {
-            await utils.handleTour(// eslint-disable-line no-await-in-loop
+            await utils.handleTour( 
               'createDocs', 
               receiver.value.tour,
               'tourCreated', 
@@ -214,11 +220,11 @@ class AgController {
     (async () => {
       let receiver: { value: { tour:any; token: any; }; done: any; };
       const rConsumer = client.socket.receiver('deleteTour').createConsumer();
-      while (true) { // eslint-disable-line no-constant-condition
-        receiver = await rConsumer.next();// eslint-disable-line no-await-in-loop
+      while (true) {  
+        receiver = await rConsumer.next(); 
         debug(`received deleteTour message: ${JSON.stringify(receiver.value)}`);
         if (!receiver.value) break;
-        await utils.removeTour(receiver, client, this.tourController, this.server);// eslint-disable-line no-await-in-loop
+        await utils.removeTour(receiver, client, this.tourController, this.server); 
         /* istanbul ignore else */if (receiver.done) break;
       }
     })();
@@ -227,7 +233,7 @@ class AgController {
   async updateTour(
     data: { tourId: mongoose.Types.ObjectId; tour: Record<string, unknown>; },
   ):Promise<string> {
-    let r: any;// eslint-disable-next-line security/detect-object-injection
+    let r: any; 
     try { 
       const { tourId, tour } = data;
       if (!tour.venue || !tour.datetime || !tour.city || !tour.usState) throw new Error('Invalid gig data');
@@ -245,15 +251,15 @@ class AgController {
     (async () => {
       let receiver: { value:any; done: any; };
       const rConsumer = client.socket.receiver(action).createConsumer();
-      while (true) { // eslint-disable-line no-constant-condition
-        receiver = await rConsumer.next();// eslint-disable-line no-await-in-loop
+      while (true) {  
+        receiver = await rConsumer.next(); 
         const obj = JSON.stringify(receiver.value);
         debug(`received ${action} message: ${obj}`);
         if (!receiver.value) break;
         if (typeof receiver.value.token === 'string') {
-          // eslint-disable-next-line security/detect-object-injection
-          if (action === 'editTour') await this.updateTour(receiver.value);// eslint-disable-line no-await-in-loop
-          // eslint-disable-next-line no-await-in-loop
+           
+          if (action === 'editTour') await this.updateTour(receiver.value); 
+           
           else await this.updateImage(receiver.value, client);
         }
         /* istanbul ignore else */if (receiver.done) break;

--- a/src/AgController/utils.ts
+++ b/src/AgController/utils.ts
@@ -40,7 +40,7 @@ async function handleTour(
 async function removeTour(receiver:any, client:any, tourController:any, server:any) {
   try {
     if (typeof receiver.value.tour.tourId === 'string' && typeof receiver.value.token === 'string') {
-      await handleTour('deleteById', receiver.value.tour.tourId, 'tourDeleted', tourController, server);// eslint-disable-line no-await-in-loop
+      await handleTour('deleteById', receiver.value.tour.tourId, 'tourDeleted', tourController, server); 
     }
   } catch (e) { 
     const eMessage = (e as Error).message;

--- a/src/app/agServerUtils.ts
+++ b/src/app/agServerUtils.ts
@@ -9,8 +9,8 @@ const handleConnections = async (
   cConsumer:ConsumableStream.Consumer<socketClusterServer.AGServer.ConnectionData>, 
   agController: AgController,
 ) => {
-  while (true) { // eslint-disable-line no-constant-condition
-    const socket = await cConsumer.next();// eslint-disable-line no-await-in-loop
+  while (true) {  
+    const socket = await cConsumer.next(); 
     debug(`new connection with id: ${socket.value.id}`);
     agController.addSocket(socket.value);
     /* istanbul ignore else */if (socket.done) break;
@@ -30,8 +30,8 @@ const setupErrorWarning = (agServer: socketClusterServer.AGServer, type: any): v
   (async () => {
     let msg;
     const eConsumer = agServer.listener(type).createConsumer();
-    while (true) { // eslint-disable-line no-constant-condition
-      msg = await eConsumer.next();// eslint-disable-line no-await-in-loop
+    while (true) {  
+      msg = await eConsumer.next(); 
       debug(type);
       debug(msg.value);
       /* istanbul ignore else */if (msg.done) break;
@@ -46,7 +46,7 @@ const handleErrAndWarn = (SOCKETCLUSTER_LOG_LEVEL: any, SOCKETCLUSTER_PORT: any,
     /* istanbul ignore else */if (color) fullMessage = `\x1b[${color}m${message}\x1b[0m`;
     return fullMessage;
   }
-  /* istanbul ignore else */if (SOCKETCLUSTER_LOG_LEVEL >= 2) { // eslint-disable-next-line no-console
+  /* istanbul ignore else */if (SOCKETCLUSTER_LOG_LEVEL >= 2) {  
     console.log(`   ${colorText('[Active]', 32)} SocketCluster worker with PID ${process.pid} is listening on port ${SOCKETCLUSTER_PORT}`);
     setupErrorWarning(agServer, 'warning');
   }

--- a/src/app/appUtils.ts
+++ b/src/app/appUtils.ts
@@ -17,8 +17,8 @@ const setup = (expressApp: any, httpServer: any): any => { // Add GET /health-ch
   (async () => { // HTTP request handling
     let packet;
     const consumer = httpServer.listener('request').createConsumer();
-    while (true) { // eslint-disable-line no-constant-condition
-      packet = await consumer.next();// eslint-disable-line no-await-in-loop
+    while (true) {  
+      packet = await consumer.next(); 
       handleRequest(expressApp, packet.value);
       /* istanbul ignore else */if (packet.done) break;
     }

--- a/src/model/db.ts
+++ b/src/model/db.ts
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV === 'test') uri = process.env.TEST_DB || /* istanbul ig
 /* istanbul ignore next */
 mongoose.connection.on('error', (e) => {
   if (process.env.NODE_ENV !== 'test') throw new Error(`unable to connect to database: ${uri}`);
-  else console.log(e.message);// eslint-disable-line no-console
+  else console.log(e.message); 
 });
 
 export default mongoose;


### PR DESCRIPTION
## Summary

- Adds `eslint-plugin-sonarjs@^4` to the flat config (`sonarjs.configs.recommended`).
- Fixes the 6 sonarjs errors surfaced on `dev`: 1 readability bug fix (no-unenclosed-multiline-block in `src/AgController/index.ts:99`), 1 inline disable with justification (pseudo-random for the pulse heartbeat), and 1 test-files-only override block disabling `no-nested-functions` for mock factories.
- `eslint --fix` cleaned up ~35 stale `// eslint-disable-line` comments for rules that aren't active anymore.

## Not addressed (out of scope)

86 pre-existing `@typescript-eslint/no-explicit-any` **warnings** remain. They predate this PR and the rule is already configured as `warn`, not `error`, so they don't fail the build. Separate cleanup if desired.

## Test plan

- [x] `npx eslint .` → 0 errors (86 pre-existing `no-explicit-any` warnings remain)
- [x] `npm test` → 66/66 tests pass
- [ ] Spot-check the readability fix in `src/AgController/index.ts:99-104` — braces around `else { break; }` and the istanbul-ignore comment moved to its own line.
- [ ] Confirm the test-files override block is appropriately scoped.

Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)