### PR TITLE
feat(newTour): check user privileges before role-based fallback

### DIFF
--- a/src/AgController/index.ts
+++ b/src/AgController/index.ts
@@ -192,9 +192,7 @@ class AgController {
           if (!userRes.ok) throw new Error(`${userRes.status} ${userRes.statusText}`);
           user = await userRes.json();
           goodRoles = JSON.parse(process.env.userRoles || /* istanbul ignore next */'{}').roles;
-          if (!goodRoles || !user || !user.userType || goodRoles.indexOf(user.userType) === -1) {
-            throw new Error('Not allowed to create new tour');
-          }
+          utils.assertCanCreateTour(user, goodRoles);
           if (receiver.value.tour.datetime && receiver.value.tour.city 
             && receiver.value.tour.usState && receiver.value.tour.venue) {
             await utils.handleTour( 

--- a/src/AgController/utils.ts
+++ b/src/AgController/utils.ts
@@ -49,4 +49,20 @@ async function removeTour(receiver:any, client:any, tourController:any, server:a
   }
 }
 
-export default { resetData, removeTour, handleTour };
+function assertCanCreateTour(
+  user: { userType?: string; privileges?: string[] } | null | undefined,
+  goodRoles: string[] | undefined,
+): void {
+  if (!user) throw new Error('Not allowed to create new tour');
+  if (Array.isArray(user.privileges) && user.privileges.length > 0) {
+    if (!user.privileges.includes('tour:create')) throw new Error('missing capability tour:create');
+    return;
+  }
+  if (!goodRoles || !user.userType || goodRoles.indexOf(user.userType) === -1) {
+    throw new Error('Not allowed to create new tour');
+  }
+}
+
+export default {
+  resetData, removeTour, handleTour, assertCanCreateTour,
+};

--- a/test/AgController/index.spec.ts
+++ b/test/AgController/index.spec.ts
@@ -302,6 +302,78 @@ describe('AgControler', () => {
     expect(clientStub.socket.transmit).toHaveBeenCalledWith('socketError', { newTour: 'Not allowed to create new tour' });
   });
 
+  it('allows newTour when user has tour:create privilege (capability path)', async () => {
+    const agController = new AgController(aStub);
+    agController.clients = ['123'];
+    agController.tourController.createDocs = vi.fn(() => Promise.resolve([]));
+    const cStub:any = {
+      socket: {
+        id: '123',
+        listener: () => ({ createConsumer: () => ({ next: () => Promise.resolve({ done: true, value: '1000' }) }) }),
+        transmit: () => { },
+        receiver: () => ({
+          createConsumer: () => ({
+            next: () => Promise.resolve({
+              value: {
+                token: 'token',
+                tour: {
+                  venue: 'venue', datetime: new Date(), city: 'city', usState: 'state',
+                },
+              },
+              done: true,
+            }),
+          }),
+        }),
+      },
+    };
+    const setIntervalMock:any = vi.fn((cb:any) => cb());
+    global.setInterval = setIntervalMock;
+    agController.jwt.verify = vi.fn(() => '123') as any;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ userType: 'unrecognized-role', privileges: ['tour:create'] }),
+    }));
+    agController.newTour(cStub);
+    await delay(1000);
+    expect(agController.tourController.createDocs).toHaveBeenCalled();
+  });
+
+  it('rejects newTour with missing capability error when privileges lack tour:create', async () => {
+    const agController = new AgController(aStub);
+    agController.clients = ['123'];
+    agController.tourController.createDocs = vi.fn(() => Promise.resolve([]));
+    const cStub:any = {
+      socket: {
+        id: '123',
+        listener: () => ({ createConsumer: () => ({ next: () => Promise.resolve({ done: true, value: '1000' }) }) }),
+        transmit: vi.fn(),
+        receiver: () => ({
+          createConsumer: () => ({
+            next: () => Promise.resolve({
+              value: {
+                token: 'token',
+                tour: {
+                  venue: 'venue', datetime: new Date(), city: 'city', usState: 'state',
+                },
+              },
+              done: true,
+            }),
+          }),
+        }),
+      },
+    };
+    const setIntervalMock:any = vi.fn((cb:any) => cb());
+    global.setInterval = setIntervalMock;
+    agController.jwt.verify = vi.fn(() => '123') as any;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ userType: 'unrecognized-role', privileges: ['song:read'] }),
+    }));
+    agController.newTour(cStub);
+    await delay(1000);
+    expect(cStub.socket.transmit).toHaveBeenCalledWith('socketError', { newTour: 'missing capability tour:create' });
+  });
+
   it('return the invalid request socketError when processes the newTour message from client', async () => {
     const agController = new AgController(aStub);
     agController.clients = ['123'];


### PR DESCRIPTION
## Summary

- Migrates the SCS `newTour` handler to check `user.privileges.includes('tour:create')` first, with a fallback to the existing `userRoles`-based check when `privileges` is empty.
- Extracted the auth check into `utils.assertCanCreateTour` to keep `newTour` under the cognitive-complexity ceiling.
- Companion to web-jam-back PR #758 — that PR adds the `privileges` field on User and the admin routes that populate it.

## Backward compatibility

- Existing users have no `privileges` set; they continue authorizing via `userType` exactly as before.
- Only users created via the new JaMmusic admin UI will have populated `privileges` arrays.
- Other SCS handlers (`editTour`, `removeTour`, etc.) are unchanged — they still gate purely on `userType`. Future PRs migrate them as needed.

## Test plan

- [x] Lint clean (`npm run test:lint`)
- [x] Typecheck clean (`npm run typecheck`)
- [x] 68 unit tests pass (`npm run test:unit`), including two new tests for the capability-allowed and capability-missing paths
- [ ] Companion web-jam-back PR #758 merged
- [ ] End-to-end smoke: create an AI-agent user with `privileges: ['tour:create']`, mint a token, transmit `newTour`, confirm gig is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)