### PR TITLE
chore: standardize BUILD_BRANCH/prod branch master->main

### DIFF
--- a/docs/e2e-playwright-plan.md
+++ b/docs/e2e-playwright-plan.md
@@ -4,7 +4,7 @@ This is a parked plan for automating the manual "create gig on the music page" s
 
 ## Why
 
-There is no hosted dev environment; `master` deploys to Heroku. The current pre-merge safety net is a manual two-terminal smoke (see [`README.md`](../README.md) "Local smoke testing"). One automated end-to-end test that creates a gig would catch the highest-risk regressions on every PR — express route changes, the fetch-migrated auth call in `AgController.newTour`, mongoose CRUD, socketcluster publish, JaMmusic ↔ cluster wire format.
+There is no hosted dev environment; `main` deploys to Heroku. The current pre-merge safety net is a manual two-terminal smoke (see [`README.md`](../README.md) "Local smoke testing"). One automated end-to-end test that creates a gig would catch the highest-risk regressions on every PR — express route changes, the fetch-migrated auth call in `AgController.newTour`, mongoose CRUD, socketcluster publish, JaMmusic ↔ cluster wire format.
 
 ## Goal
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webjamsocketserver",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webjamsocketserver",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjamsocketserver",
   "description": "Uses latest version of socketcluster-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "type": "module",
   "main": "build/src/index.js",

--- a/postinstallJaM.sh
+++ b/postinstallJaM.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-BRANCH=master
+BRANCH=main
 
-if [[ $BUILD_BRANCH != "master" ]];
+if [[ $BUILD_BRANCH != "main" ]];
 then
     BRANCH=dev
 fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ const expressApp = express();
   expressApp.use(morgan('dev'));// Log every HTTP request. See https://github.com/expressjs/morgan for available formats.
 }
 /* istanbul ignore next */
-if (process.env.NODE_ENV === 'production' && process.env.BUILD_BRANCH === 'master') expressApp.use(enforce.HTTPS({ trustProtoHeader: true }));
+if (process.env.NODE_ENV === 'production' && process.env.BUILD_BRANCH === 'main') expressApp.use(enforce.HTTPS({ trustProtoHeader: true }));
 expressApp.use(express.static(path.normalize(path.join(import.meta.dirname, '../../JaMmusic/dist'))));
 routeUtils.setRoot(expressApp);
 appUtils.setup(expressApp, httpServer);


### PR DESCRIPTION
## What
Part of the org-wide `master` → `main` standardization (Task 7). `BUILD_BRANCH` is both a Heroku config var and a code flag:

- **`postinstallJaM.sh`** — prod build now checks out JaMmusic's **`main`** branch (was `master`); non-prod still uses `dev`.
- **`src/index.ts`** — production HTTPS enforcement now keys on `BUILD_BRANCH === 'main'`.
- **`docs/e2e-playwright-plan.md`** — corrected deploy-branch note.

Patch bump 3.0.0 → 3.0.1. Typecheck passes.

## ⚠️ Must land coordinated
This deploy will `git checkout main` on JaMmusic, so it is only safe **after**:
1. JaMmusic `master` → `main` rename is done, AND
2. `heroku config:set BUILD_BRANCH=main -a webjamsocket`, AND
3. webjamsocket's GitHub auto-deploy branch repointed `master` → `main`.

If deployed with `BUILD_BRANCH` still `master`, postinstall would build JaMmusic `dev` into prod and HTTPS enforcement would turn off. Do not promote to prod standalone.

## How to Test Locally
```bash
git checkout chore-build-branch-main
npm install
npm run typecheck && npm test
grep -n master postinstallJaM.sh src/index.ts   # => no matches
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)