### PR TITLE
Promote dev to main: BUILD_BRANCH master->main standardization

### DIFF
--- a/docs/e2e-playwright-plan.md
+++ b/docs/e2e-playwright-plan.md
@@ -4,7 +4,7 @@ This is a parked plan for automating the manual "create gig on the music page" s
 
 ## Why
 
-There is no hosted dev environment; `master` deploys to Heroku. The current pre-merge safety net is a manual two-terminal smoke (see [`README.md`](../README.md) "Local smoke testing"). One automated end-to-end test that creates a gig would catch the highest-risk regressions on every PR — express route changes, the fetch-migrated auth call in `AgController.newTour`, mongoose CRUD, socketcluster publish, JaMmusic ↔ cluster wire format.
+There is no hosted dev environment; `main` deploys to Heroku. The current pre-merge safety net is a manual two-terminal smoke (see [`README.md`](../README.md) "Local smoke testing"). One automated end-to-end test that creates a gig would catch the highest-risk regressions on every PR — express route changes, the fetch-migrated auth call in `AgController.newTour`, mongoose CRUD, socketcluster publish, JaMmusic ↔ cluster wire format.
 
 ## Goal
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webjamsocketserver",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webjamsocketserver",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjamsocketserver",
   "description": "Uses latest version of socketcluster-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "type": "module",
   "main": "build/src/index.js",

--- a/postinstallJaM.sh
+++ b/postinstallJaM.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-BRANCH=master
+BRANCH=main
 
-if [[ $BUILD_BRANCH != "master" ]];
+if [[ $BUILD_BRANCH != "main" ]];
 then
     BRANCH=dev
 fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ const expressApp = express();
   expressApp.use(morgan('dev'));// Log every HTTP request. See https://github.com/expressjs/morgan for available formats.
 }
 /* istanbul ignore next */
-if (process.env.NODE_ENV === 'production' && process.env.BUILD_BRANCH === 'master') expressApp.use(enforce.HTTPS({ trustProtoHeader: true }));
+if (process.env.NODE_ENV === 'production' && process.env.BUILD_BRANCH === 'main') expressApp.use(enforce.HTTPS({ trustProtoHeader: true }));
 expressApp.use(express.static(path.normalize(path.join(import.meta.dirname, '../../JaMmusic/dist'))));
 routeUtils.setRoot(expressApp);
 appUtils.setup(expressApp, httpServer);


### PR DESCRIPTION
Promotes `dev` to `main` so prod (`webjamsocket`) builds with the `master`→`main` standardization: `postinstallJaM.sh` checks out JaMmusic `main`, and HTTPS enforcement keys on `BUILD_BRANCH==='main'`.

Paired with `heroku config:set BUILD_BRANCH=main -a webjamsocket` and the dashboard auto-deploy repoint to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)