### PR TITLE
ci: redeploy webjamsocket when JaMmusic merges to main (Task 195b receiver)

### DIFF
--- a/.github/workflows/redeploy-on-jammusic.yml
+++ b/.github/workflows/redeploy-on-jammusic.yml
@@ -1,0 +1,23 @@
+name: Redeploy on JaMmusic main update
+
+# Fired by a repository_dispatch from JaMmusic when it merges to main, so the
+# embedded JaMmusic build (via postinstallJaM) is refreshed. Also runnable by
+# hand from the Actions tab (workflow_dispatch).
+on:
+  repository_dispatch:
+    types: [jammusic-main-deploy]
+  workflow_dispatch: {}
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Heroku build of current main
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          curl -fsS -X POST https://api.heroku.com/apps/webjamsocket/builds \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/vnd.heroku+json; version=3" \
+            -H "Authorization: Bearer $HEROKU_API_KEY" \
+            -d '{"source_blob":{"url":"https://github.com/WebJamApps/WebJamSocketCluster/tarball/main","version":"main"}}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webjamsocketserver",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webjamsocketserver",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjamsocketserver",
   "description": "Uses latest version of socketcluster-server",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "type": "module",
   "main": "build/src/index.js",


### PR DESCRIPTION
## What

Adds `.github/workflows/redeploy-on-jammusic.yml` — rebuilds the **webjamsocket** Heroku app (serves joshandmariamusic.com) whenever JaMmusic merges to `main`, so the embedded JaMmusic frontend (pulled in at build time by `postinstallJaM`) stays current.

This is **receiver #2** of the Task 195(b) fan-out. Triggered by a `repository_dispatch` (`jammusic-main-deploy`) from the JaMmusic dispatcher (separate PR); also runnable by hand via `workflow_dispatch`.

The step calls the Heroku Platform API to build current `main` from its public GitHub source tarball — running the full buildpack incl. `postinstallJaM`, which re-pulls JaMmusic `main`. Idempotent, no empty commits.

## Required secret (add before this does anything)

- `HEROKU_API_KEY` — repo secret, a Heroku API token authorized for the `webjamsocket` app.

## How to Test Locally

Runs on GitHub's runners, but you can validate + dry-run:

```bash
# 1. Validate the workflow YAML
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/redeploy-on-jammusic.yml')); print('valid')"

# 2. After merging + adding HEROKU_API_KEY, trigger it manually:
gh workflow run "Redeploy on JaMmusic main update" -R WebJamApps/WebJamSocketCluster
gh run watch -R WebJamApps/WebJamSocketCluster

# 3. Confirm a new Heroku build/release (requires Heroku auth — your call):
#    heroku builds -a webjamsocket   |   heroku releases -a webjamsocket
```

Part of the Task 195(b) fan-out tracked in JaMmusic#1071. Companion PRs: web-jam-back#775 receiver + JaMmusic dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)