### PR TITLE
Failed gig update reports nothing: updateGig swallows its error, so neither socketError nor gigUpdated is emitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjamsocketserver",
   "description": "Uses latest version of socketcluster-server",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "license": "MIT",
   "type": "module",
   "main": "build/src/index.js",

--- a/src/AgController/index.ts
+++ b/src/AgController/index.ts
@@ -308,9 +308,13 @@ class AgController {
       if (!gig.venue || !gig.datetime || !gig.city || !gig.usState) throw new Error('Invalid gig data');
       r = await this.gigController.findByIdAndUpdate(id, gig);
     } catch (e) {
-      const eMessage = (e as Error).message;
-      debug(eMessage);
-      return eMessage;
+      // Rethrow (#253, same pattern as handleImage/JaMmusic#1199): swallowing
+      // this and returning the error message meant editDoc's catch (which
+      // already transmits socketError) never saw the failure, so neither
+      // socketError nor gigUpdated was ever sent. Let editDoc's own try/catch
+      // handle it.
+      debug((e as Error).message);
+      throw e;
     }
     this.server.exchange.transmitPublish('gigUpdated', r);
     return 'Gig updated';

--- a/test/AgController/index.spec.ts
+++ b/test/AgController/index.spec.ts
@@ -263,16 +263,22 @@ describe('AgControler', () => {
     });
     expect(r).toBe('Gig updated');
   });
-  it('handles error from updates a tours', async () => {
+  it('rethrows a database failure from updateGig instead of swallowing it (#253)', async () => {
     const agController = new AgController(aStub);
     agController.gigController.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('bad')));
-    r = await agController.updateGig({
+    await expect(agController.updateGig({
       tourId: testId,
       tour: {
-        venue: 'venue', datetime: new Date(), city: 'city', usState: 'state', 
-      }, 
-    });
-    expect(r).toBe('bad');
+        venue: 'venue', datetime: new Date(), city: 'city', usState: 'state',
+      },
+    })).rejects.toThrow('bad');
+  });
+  it('rethrows a validation failure from updateGig instead of swallowing it (#253)', async () => {
+    const agController = new AgController(aStub);
+    await expect(agController.updateGig({
+      gigId: testId,
+      gig: {},
+    })).rejects.toThrow('Invalid gig data');
   });
   it('does not process the newTour message from client when token is not valid', async () => {
     const agController = new AgController(aStub);
@@ -1010,6 +1016,128 @@ describe('AgControler', () => {
     agController.server.exchange.transmitPublish = vi.fn();
     agController.editDoc(sStub, 'editTour');
     await delay(1000);
+    expect(agController.server.exchange.transmitPublish).not.toHaveBeenCalled();
+  });
+  it('transmits socketError with Invalid gig data when editGig fails validation (#253)', async () => {
+    const agController = new AgController(aStub);
+    agController.clients = ['123'];
+    agController.verifyAdminWrite = vi.fn(() => Promise.resolve());
+    const sStub:any = {
+      socket: {
+        id: '123',
+        transmit: vi.fn(),
+        receiver: () => ({
+          createConsumer: () => ({
+            next: () => Promise.resolve({
+              value: {
+                gigId: '123',
+                token: 'token',
+                gig: {},
+              },
+              done: true,
+            }),
+          }),
+        }),
+      },
+    };
+    agController.server.exchange.transmitPublish = vi.fn();
+    agController.editDoc(sStub, 'editGig');
+    await delay(1000);
+    expect(sStub.socket.transmit).toHaveBeenCalledWith('socketError', { editGig: 'Invalid gig data' });
+    expect(agController.server.exchange.transmitPublish).not.toHaveBeenCalled();
+  });
+  it('transmits socketError with the db message when editGig fails at the database layer (#253)', async () => {
+    const agController = new AgController(aStub);
+    agController.clients = ['123'];
+    agController.verifyAdminWrite = vi.fn(() => Promise.resolve());
+    agController.gigController.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('db exploded')));
+    const sStub:any = {
+      socket: {
+        id: '123',
+        transmit: vi.fn(),
+        receiver: () => ({
+          createConsumer: () => ({
+            next: () => Promise.resolve({
+              value: {
+                gigId: '123',
+                token: 'token',
+                gig: {
+                  venue: 'venue', datetime: new Date(), city: 'city', usState: 'state',
+                },
+              },
+              done: true,
+            }),
+          }),
+        }),
+      },
+    };
+    agController.server.exchange.transmitPublish = vi.fn();
+    agController.editDoc(sStub, 'editGig');
+    await delay(1000);
+    expect(sStub.socket.transmit).toHaveBeenCalledWith('socketError', { editGig: 'db exploded' });
+    expect(agController.server.exchange.transmitPublish).not.toHaveBeenCalled();
+  });
+  it('publishes gigUpdated exactly once and transmits no socketError on a successful editGig (#253)', async () => {
+    const agController = new AgController(aStub);
+    agController.clients = ['123'];
+    agController.verifyAdminWrite = vi.fn(() => Promise.resolve());
+    agController.gigController.findByIdAndUpdate = vi.fn(() => Promise.resolve({ _id: '123' }));
+    const sStub:any = {
+      socket: {
+        id: '123',
+        transmit: vi.fn(),
+        receiver: () => ({
+          createConsumer: () => ({
+            next: () => Promise.resolve({
+              value: {
+                gigId: '123',
+                token: 'token',
+                gig: {
+                  venue: 'venue', datetime: new Date(), city: 'city', usState: 'state',
+                },
+              },
+              done: true,
+            }),
+          }),
+        }),
+      },
+    };
+    agController.server.exchange.transmitPublish = vi.fn();
+    agController.editDoc(sStub, 'editGig');
+    await delay(1000);
+    expect(agController.server.exchange.transmitPublish).toHaveBeenCalledTimes(1);
+    expect(agController.server.exchange.transmitPublish).toHaveBeenCalledWith('gigUpdated', { _id: '123' });
+    expect(sStub.socket.transmit).not.toHaveBeenCalledWith('socketError', expect.anything());
+  });
+  it('behaves identically for the legacy editTour alias on a database failure (#253)', async () => {
+    const agController = new AgController(aStub);
+    agController.clients = ['123'];
+    agController.verifyAdminWrite = vi.fn(() => Promise.resolve());
+    agController.gigController.findByIdAndUpdate = vi.fn(() => Promise.reject(new Error('bad')));
+    const sStub:any = {
+      socket: {
+        id: '123',
+        transmit: vi.fn(),
+        receiver: () => ({
+          createConsumer: () => ({
+            next: () => Promise.resolve({
+              value: {
+                tourId: '123',
+                token: 'token',
+                tour: {
+                  venue: 'venue', datetime: new Date(), city: 'city', usState: 'state',
+                },
+              },
+              done: true,
+            }),
+          }),
+        }),
+      },
+    };
+    agController.server.exchange.transmitPublish = vi.fn();
+    agController.editDoc(sStub, 'editTour');
+    await delay(1000);
+    expect(sStub.socket.transmit).toHaveBeenCalledWith('socketError', { editTour: 'bad' });
     expect(agController.server.exchange.transmitPublish).not.toHaveBeenCalled();
   });
   it('handles missing token when the deleteTour message from client', async () => {


### PR DESCRIPTION
## Summary
- `updateGig` (`src/AgController/index.ts`) now rethrows instead of returning the error message as a string, so `editDoc`'s existing catch is the single place that transmits `socketError` (matching the pattern already used by `handleGig`/`handleImage`, JaMmusic#1199)
- No second `socketError` transmit was added inside `updateGig` — the caller still owns that
- Kept the `debug(eMessage)` server-log line on the rethrow path
- Create (`utils.handleGig`) and delete (`utils.removeGig`) paths are untouched
- Added unit tests: direct `updateGig` rejection for both validation failure and database failure, plus `editDoc`-level integration tests asserting `socketError { editGig: ... }` on validation/db failure, a single `gigUpdated` publish with no `socketError` on success, and that the legacy `editTour` alias behaves identically to `editGig` on failure

Closes #253

## How to test locally
Run:
```sh
npm test
```
Expect: eslint 0 errors, typecheck clean, vitest 91/91 green.

To exercise the change itself (what actually changed client-visible behavior): connect a socket client, authenticate, and send an `editGig` message with a payload missing a required field, e.g.:
```js
socket.transmit('editGig', { token: 'YOUR_ADMIN_JWT', gigId: 'YOUR_GIG_ID', gig: {} });
```
Before this fix: the client received neither `socketError` nor `gigUpdated` — nothing at all; only the server `debug` log showed `Invalid gig data`.
After this fix: the client receives `socketError` with payload `{ editGig: 'Invalid gig data' }`. The same holds for a database-layer failure (e.g. a malformed `gigId`) — the client now gets `socketError` carrying the underlying db error message under the `editGig` key, instead of silence. A valid `editGig` payload still publishes `gigUpdated` exactly once with no `socketError`. `editTour` (legacy alias) behaves identically.

## Test evidence
```
> webjamsocketserver@3.0.11 test
> eslint . && npm run typecheck && rimraf coverage && npm run test:unit

✖ 105 problems (0 errors, 105 warnings)

> webjamsocketserver@3.0.11 typecheck
> tsc --noEmit

> webjamsocketserver@3.0.11 test:unit
> vitest run

 RUN  v4.1.9 /home/joshua/WebJamApps/WebJamSocketCluster

 Test Files  10 passed (10)
      Tests  91 passed (91)
   Start at  05:57:20
   Duration  39.73s (transform 1.04s, setup 0ms, import 3.28s, tests 43.15s, environment 2ms)
```
(105 warnings are all pre-existing `@typescript-eslint/no-explicit-any`, unrelated to this change; 0 errors.)

🤖 Work by Claude Code — Sonnet 5