### PR TITLE
docs: add repository AGENTS.md guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Guidelines for WebJamSocketCluster
+
+## TypeScript & Type Safety
+- **No `any`**: `@typescript-eslint/no-explicit-any` is set to `'error'`. Do not disable this rule or use `: any` or `as any`.
+- **Shared Domain Types**: Centralized types for socket connections, streams, payloads, and domain objects live in `src/types/index.ts`.
+- **Mongoose Generic Facade**: Model facades extend `Facade<T>` defined in `src/lib/facade.ts`. When typing generic model methods, use double type assertions (e.g. `(await ... as unknown) as T[]`) to satisfy Mongoose generic method signatures without using `any`.
+- **SocketCluster Mocks**: When mocking `AGServer` or `IClient` in tests, cast stub objects using `as unknown as socketClusterServer.AGServer` or `as unknown as IClient`. Ensure `receiver.next()` mocks return `{ value?: T; done?: boolean }`.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` repository guidelines to document TypeScript strict typing standards, SocketCluster mocking conventions, and generic model facade casting patterns.

## How to test locally
1. Verify `AGENTS.md` exists and contains repository guidelines.
2. Run `npm test` to ensure linting and all unit tests remain green.

## Test evidence
```
> webjamsocketserver@3.0.13 test
> eslint . && npm run typecheck && rimraf coverage && npm run test:unit

> webjamsocketserver@3.0.13 typecheck
> tsc --noEmit

> webjamsocketserver@3.0.13 test:unit
> vitest run

 Test Files  10 passed (10)
      Tests  99 passed (99)
   Start at  17:49:12
   Duration  43.68s
```

🤖 Work by agy — Gemini 3.6 Flash (High)