### PR TITLE
all 8 active github repos - their main branch only accepts PR requests from their dev branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,16 @@ jobs:
     steps:
       - checkout
       - run:
+          name:        PR base branch verification (main requires dev head)
+          command:     |
+            TARGET="${CIRCLE_TARGET_BRANCH:-${GITHUB_BASE_REF:-}}"
+            SOURCE="${CIRCLE_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+            if [ -n "$TARGET" ] && [ "$TARGET" = "main" ] && [ "$SOURCE" != "dev" ]; then
+              echo "FAIL: PRs targeting main must originate from dev branch (got: $SOURCE)." >&2
+              exit 1
+            fi
+            echo "OK: PR base/head branch verification passed (Target: ${TARGET:-default}, Source: $SOURCE)"
+      - run:
           name:        Test install
           command:     'npm install --ignore-scripts'
       - run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,6 @@
 - **Shared Domain Types**: Centralized types for socket connections, streams, payloads, and domain objects live in `src/types/index.ts`.
 - **Mongoose Generic Facade**: Model facades extend `Facade<T>` defined in `src/lib/facade.ts`. When typing generic model methods, use double type assertions (e.g. `(await ... as unknown) as T[]`) to satisfy Mongoose generic method signatures without using `any`.
 - **SocketCluster Mocks**: When mocking `AGServer` or `IClient` in tests, cast stub objects using `as unknown as socketClusterServer.AGServer` or `as unknown as IClient`. Ensure `receiver.next()` mocks return `{ value?: T; done?: boolean }`.
+
+## Memory & Security Audits
+- **Snyk Failures & Resolution via `npm audit fix`**: PR checks may report failure on `security/snyk` due to transitive dependency vulnerabilities. Running `npm audit fix` updates `package-lock.json` with non-breaking patches to resolve these vulnerabilities. Always run local tests afterwards to verify the test suite remains 100% green before committing and pushing `package-lock.json` to the PR branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webjamsocketserver",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webjamsocketserver",
-      "version": "3.0.15",
+      "version": "3.0.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webjamsocketserver",
   "description": "Uses latest version of socketcluster-server",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "license": "MIT",
   "type": "module",
   "main": "build/src/index.js",


### PR DESCRIPTION
## Summary
- Add PR base branch verification step to .circleci/config.yml.
- Enforce that PRs targeting main must originate from dev branch (head: dev).
- Bump version to 3.0.16 in package.json.

Part of WebJamApps/web-jam-tools#351

## How to test locally
1. Verify .circleci/config.yml includes the PR base branch verification step.
2. Run npm test in WebJamSocketCluster to verify all tests pass.

## Test evidence
```

 RUN  v4.1.9 /home/joshua/WebJamApps/WebJamSocketCluster

 ✓ test/lib/routeUtils.test.ts (1 test) 4ms
 ✓ test/lib/facade.test.ts (7 tests) 12ms
 ✓ test/app/appUtils.spec.ts (3 tests) 7ms
 ✓ test/AgController/utils.spec.ts (9 tests) 14ms
 ✓ test/lib/controller.test.ts (1 test) 6ms
stdout | test/gig/gig-facade.test.ts
◇ injected env (16) from .env // tip: ⌘ custom filepath { path: '/custom/path/.env' }

stdout | test/gig/gig-controller.test.ts
◇ injected env (16) from .env // tip: ⌘ override existing { override: true }

stdout | test/AgController/index.spec.ts
◇ injected env (16) from .env // tip: ⌘ custom filepath { path: '/custom/path/.env' }

stdout | test/app/agServerUtils.spec.ts
◇ injected env (16) from .env // tip: ⌁ auth for agents [www.vestauth.com]

 ✓ test/gig/gig-facade.test.ts (4 tests) 10ms
stdout | test/app/agServerUtils.spec.ts > agServerUtils > handles errors and warnings
   [32m[Active][0m SocketCluster worker with PID 117450 is listening on port 8888

stdout | test/server.spec.ts
◇ injected env (16) from .env // tip: ⌘ multiple files { path: ['.env.local', '.env'] }

stdout | test/server.spec.ts
◇ injected env (0) from .env // tip: ⌘ override existing { override: true }
   [32m[Active][0m SocketCluster worker with PID 117443 is listening on port 8888

 ✓ test/gig/gig-controller.test.ts (11 tests) 1016ms
     ✓ should wait unit tests finish before exiting  1001ms
 ✓ test/app/agServerUtils.spec.ts (3 tests) 1009ms
     ✓ should wait unit tests finish before exiting  1001ms
 ✓ test/server.spec.ts (1 test) 2004ms
     ✓ is defines the server  2003ms
```

🤖 Work by agy — Gemini 3.6 Flash (High)